### PR TITLE
Staging for decimation support

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -20,7 +20,7 @@ export const QueryEditor: React.FC<Props> = ({ app, query, datasource, onChange,
   };
 
   const handleColumnChange = (items: Array<SelectableValue<string>>) => {
-    const columns = items.map(({ value, dataType }) => ({ name: value!, dataType }));
+    const columns = items.map(({ value, dataType, columnType }) => ({ name: value!, dataType, columnType }));
     onChange({ ...query, columns });
   };
 
@@ -47,5 +47,5 @@ export const QueryEditor: React.FC<Props> = ({ app, query, datasource, onChange,
 };
 
 const columnsToOptions = (columns: Column[] | QueryColumn[] = []): Array<SelectableValue<string>> => {
-  return columns.map(({ name, dataType }) => ({ label: name, value: name, dataType }));
+  return columns.map(({ name, dataType, columnType }) => ({ label: name, value: name, dataType, columnType }));
 };

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -101,8 +101,8 @@ it('should automatically apply time filters when index column is a timestamp', a
     expect.objectContaining({
       data: expect.objectContaining({
         filters: [
-          { column: 'time', operation: 'GREATER_THAN_EQUALS', value: '2022-09-14T00:00:00.000Z' },
-          { column: 'time', operation: 'LESS_THAN_EQUALS', value: '2022-09-16T00:00:00.000Z' },
+          { column: 'time', operation: 'GREATER_THAN_EQUALS', value: from.toISOString() },
+          { column: 'time', operation: 'LESS_THAN_EQUALS', value: to.toISOString() },
         ],
       }),
     })

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,31 +1,144 @@
 import { of } from 'rxjs';
-import { DataQueryRequest, DataSourceInstanceSettings, dateTime, PluginType } from '@grafana/data';
-import { FetchResponse } from '@grafana/runtime';
+import { DataQueryRequest, DataSourceInstanceSettings, dateTime, Field, FieldType } from '@grafana/data';
+import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';
 
 import { DataframeQuery } from './types';
 import { DataFrameDataSource } from './datasource';
-
-const fetchMock = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => ({ fetch: fetchMock }),
 }));
 
+const fetchMock = jest.fn<number, [BackendSrvRequest]>();
+
+let ds: DataFrameDataSource;
+
 beforeEach(() => {
   jest.clearAllMocks();
-});
-
-it('test test', async () => {
+  const instanceSettings = {
+    url: '_',
+    name: 'SystemLink Dataframes',
+  };
+  ds = new DataFrameDataSource(instanceSettings as DataSourceInstanceSettings);
   setupFetchMock(fakeDataResponse);
-
-  const ds = new DataFrameDataSource(defaultSettings);
-  const response = await ds.query({
-    ...defaultQuery,
-    targets: [{ refId: 'A', tableId: '123', columns: [{ name: 'col', dataType: 'FLOAT32' }] }],
-  });
-  expect(response).toBeTruthy();
 });
+
+it('should return no data if there are no valid queries', async () => {
+  const query = buildQuery([
+    { refId: 'A' }, // initial state when creating a panel
+    { refId: 'B', tableId: '_' }, // state after entering a table id, but no columns selected
+  ]);
+
+  const response = await ds.query(query);
+
+  expect(response.data).toHaveLength(0);
+});
+
+it('should return data ignoring invalid queries', async () => {
+  const query = buildQuery([
+    { refId: 'A', tableId: '_' }, // invalid
+    { refId: 'B', tableId: '1', columns: [{ name: 'float', dataType: 'FLOAT32', columnType: 'NORMAL' }] },
+  ]);
+
+  await ds.query(query);
+
+  expect(fetchMock).toBeCalledTimes(1);
+  expect(fetchMock).toBeCalledWith(expect.objectContaining({ url: '_/v1/tables/1/query-data' }));
+});
+
+it('should return data for multiple targets', async () => {
+  const query = buildQuery([
+    { refId: 'A', tableId: '1', columns: [{ name: 'int', dataType: 'INT32', columnType: 'NORMAL' }] },
+    { refId: 'B', tableId: '2', columns: [{ name: 'float', dataType: 'FLOAT32', columnType: 'NORMAL' }] },
+  ]);
+
+  const response = await ds.query(query);
+
+  expect(fetchMock).toBeCalledTimes(2);
+  expect(response.data).toHaveLength(2);
+});
+
+it('should convert columns to Grafana fields', async () => {
+  const query = buildQuery([
+    {
+      refId: 'A',
+      tableId: '_',
+      columns: [
+        { name: 'int', dataType: 'INT32', columnType: 'INDEX' },
+        { name: 'float', dataType: 'FLOAT32', columnType: 'NORMAL' },
+        { name: 'string', dataType: 'STRING', columnType: 'NORMAL' },
+        { name: 'time', dataType: 'TIMESTAMP', columnType: 'NORMAL' },
+        { name: 'bool', dataType: 'BOOL', columnType: 'NORMAL' },
+      ],
+    },
+  ]);
+
+  const response = await ds.query(query);
+
+  const fields = response.data[0].fields as Field[];
+  const actual = fields.map(({ name, type, values }) => ({ name, type, values: values.toArray() }));
+  expect(actual).toEqual([
+    { name: 'int', type: FieldType.number, values: [1, 2] },
+    { name: 'float', type: FieldType.number, values: [1.1, 2.2] },
+    { name: 'string', type: FieldType.string, values: ['first', 'second'] },
+    { name: 'time', type: FieldType.time, values: [1663135260000, 1663135320000] },
+    { name: 'bool', type: FieldType.boolean, values: [true, false] },
+  ]);
+});
+
+it('should automatically apply time filters when index column is a timestamp', async () => {
+  const query = buildQuery([
+    { refId: 'A', tableId: '_', columns: [{ name: 'time', dataType: 'TIMESTAMP', columnType: 'INDEX' }] },
+  ]);
+  const from = dateTime('2022-09-14T00:00:00Z');
+  const to = dateTime('2022-09-16T00:00:00Z');
+  query.range = { from, to, raw: { from, to } };
+
+  await ds.query(query);
+
+  expect(fetchMock).toBeCalledWith(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        filters: [
+          { column: 'time', operation: 'GREATER_THAN_EQUALS', value: '2022-09-14T00:00:00.000Z' },
+          { column: 'time', operation: 'LESS_THAN_EQUALS', value: '2022-09-16T00:00:00.000Z' },
+        ],
+      }),
+    })
+  );
+});
+xit('should provide decimation parameters correctly', async () => {
+  const query = buildQuery([
+    {
+      refId: 'A',
+      tableId: '_',
+      columns: [
+        { name: 'int', dataType: 'INT32', columnType: 'NORMAL' },
+        { name: 'string', dataType: 'STRING', columnType: 'NORMAL' },
+        { name: 'float', dataType: 'FLOAT32', columnType: 'NORMAL' },
+      ],
+    },
+  ]);
+  query.maxDataPoints = 300;
+
+  await ds.query(query);
+
+  expect(fetchMock).toBeCalledWith(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        decimation: { intervals: 300, method: 'MAX_MIN', yColumns: ['int', 'float'] },
+      }),
+    })
+  );
+});
+
+const buildQuery = (targets: DataframeQuery[]): DataQueryRequest<DataframeQuery> => {
+  return {
+    ...defaultQuery,
+    targets,
+  };
+};
 
 const setupFetchMock = (response: any, mock?: any) => {
   const defaultMock = () => mock ?? of(createFetchResponse(response));
@@ -48,32 +161,14 @@ const createFetchResponse = <T>(data: T): FetchResponse<T> => {
 
 const fakeDataResponse = {
   frame: {
-    columns: ['int_col', 'float_col', 'text_col'],
+    columns: ['int', 'float', 'string', 'time', 'bool'],
     data: [
-      ['1', '1.1', 'first'],
-      ['2', '2.2', 'second'],
+      ['1', '1.1', 'first', '2022-09-14T06:01:00.0000000Z', true],
+      ['2', '2.2', 'second', '2022-09-14T06:02:00.0000000Z', false],
     ],
   },
   totalRowCount: 2,
   continuationToken: '_',
-};
-
-const defaultSettings: DataSourceInstanceSettings = {
-  id: 0,
-  uid: '0',
-  type: 'tracing',
-  name: 'jaeger',
-  url: 'http://grafana.com',
-  access: 'proxy',
-  meta: {
-    id: 'ni-dataframe-datasource',
-    name: 'SystemLink Dataframes',
-    type: PluginType.datasource,
-    info: {} as any,
-    module: '',
-    baseUrl: '',
-  },
-  jsonData: {},
 };
 
 const defaultQuery: DataQueryRequest<DataframeQuery> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { DataQuery } from '@grafana/data';
 
-export type QueryColumn = Pick<Column, 'name' | 'dataType'>;
+export type QueryColumn = Pick<Column, 'name' | 'dataType' | 'columnType'>;
 
 export interface DataframeQuery extends DataQuery {
   tableId?: string;
@@ -20,6 +20,20 @@ export interface Column {
   dataType: ColumnDataType;
   columnType: 'INDEX' | 'NULLABLE' | 'NORMAL';
   properties: Record<string, string>;
+}
+
+export interface ColumnFilter {
+  column: string;
+  operation:
+    | 'EQUALS'
+    | 'LESS_THAN'
+    | 'LESS_THAN_EQUALS'
+    | 'GREATER_THAN'
+    | 'GREATER_THAN_EQUALS'
+    | 'NOT_EQUALS'
+    | 'CONTAINS'
+    | 'NOT_CONTAINS';
+  value: string;
 }
 
 export interface TableMetadata {


### PR DESCRIPTION
This is the necessary plumbing to call the decimated query route once it's live in the backend. 
The main functionality is automatically filtering data by the time range on the Grafana dashboard. We only add these filters if there's a timestamp column present and it's the index.
We also pass through the 'maxDataPoints' option on the panel as the number of buckets to use for decimation. We set the 'yColumns' parameter to all the numeric columns included in the query. For now, the decimation method is always MIN_MAX, but we'll probably add a way for the user to configure that in another change.