### PR TITLE
fix: Catch HTTP errors and bubble up correctly

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -38,7 +38,7 @@ export const QueryEditor: React.FC<Props> = ({ query, datasource, onChange, onRu
       <InlineField label="Id" error="Table does not exist" invalid={!!tableMetadata.error}>
         <Input defaultValue={query.tableId} width={26} onBlur={handleIdInputBlur} />
       </InlineField>
-      <InlineField label="Columns" tooltip="The columns to include in the response data.">
+      <InlineField label="Columns" tooltip="Specifies the columns to include in the response data.">
         <MultiSelect
           isLoading={tableMetadata.loading}
           options={columnsToOptions(tableMetadata.value?.columns)}
@@ -54,7 +54,7 @@ export const QueryEditor: React.FC<Props> = ({ query, datasource, onChange, onRu
           value={query.decimationMethod ?? defaultDecimationMethod}
         />
       </InlineField>
-      <InlineField label="Filter nulls" tooltip="Filter out null and NaN values before decimating the data.">
+      <InlineField label="Filter nulls" tooltip="Filters out null and NaN values before decimating the data.">
         <InlineSwitch
           value={query.filterNulls}
           onChange={(event) => handleQueryChange({ ...query, filterNulls: event.currentTarget.checked }, true)}
@@ -62,7 +62,7 @@ export const QueryEditor: React.FC<Props> = ({ query, datasource, onChange, onRu
       </InlineField>
       <InlineField
         label="Use time range"
-        tooltip="If the table's index is a timestamp, only query for data within the dashboard's time range. This should be enabled when interacting with your data on a graph."
+        tooltip="Queries only for data within the dashboard time range if the table index is a timestamp. Enable when interacting with your data on a graph."
       >
         <InlineSwitch
           value={query.applyTimeFilters}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ export const decimationMethods = [
   {
     value: 'LOSSY',
     label: 'Lossy',
-    description: nbsp`Faster, but not as accurate`
+    description: nbsp`Completes faster but is less accurate`
   },
   {
     value: 'MAX_MIN',


### PR DESCRIPTION
When the HTTP request to query for data fails for whatever reason, Grafana _dashboards_ handle the uncaught exception gracefully. Grafana _Explore_, however, does this:

![Screen Shot 2022-09-22 at 2 24 47 PM](https://user-images.githubusercontent.com/9257800/191833820-2dcfa6c9-9a0f-4046-a912-fe17760efad3.png)
(Completely crashes)

This change wraps the requests in a try catch and then parses the error into the format Grafana expects.
I also pulled in the string feedback that Melissa gave after the [last PR](https://github.com/ni/systemlink-dataframe-datasource/pull/2) went in. 