### PR TITLE
Query tables by name

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -43,7 +43,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
       .queryTables(query)
       .then((tables) => cb?.(tables.map((t) => ({ label: t.name, value: t.id, description: t.id }))))
       .catch(handleError);
-  }, 500);
+  }, 300);
 
   const handleLoadOptions = (query: string, cb?: LoadOptionsCallback<string>) => {
     if (!query || query.startsWith('$')) {

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,13 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { useAsync, useTimeoutFn } from 'react-use';
+import React, { useState } from 'react';
+import { useAsync } from 'react-use';
 import { QueryEditorProps, SelectableValue, toOption } from '@grafana/data';
 import { DataFrameDataSource } from './datasource';
-import { Column, DataframeQuery, isSystemLinkError, isValidQuery, QueryColumn } from './types';
-import { InlineField, InlineSwitch, MultiSelect, Select, Alert, AsyncSelect, LoadOptionsCallback } from '@grafana/ui';
-import { decimationMethods, defaultDecimationMethod, errorCodes } from './constants';
+import { Column, DataframeQuery, isValidQuery, QueryColumn } from './types';
+import { InlineField, InlineSwitch, MultiSelect, Select, AsyncSelect, LoadOptionsCallback } from '@grafana/ui';
+import { decimationMethods, defaultDecimationMethod } from './constants';
 import _ from 'lodash';
-import { getTemplateSrv, isFetchError } from '@grafana/runtime';
+import { getTemplateSrv } from '@grafana/runtime';
 import { isValidId } from 'utils';
+import { FloatingError, parseErrorMessage } from 'errors';
 
 type Props = QueryEditorProps<DataFrameDataSource, DataframeQuery>;
 
@@ -114,30 +115,4 @@ const getVariableOptions = () => {
   return getTemplateSrv()
     .getVariables()
     .map((v) => toOption('$' + v.name));
-};
-
-const FloatingError = ({ message = '' }) => {
-  const [hide, setHide] = useState(false);
-  const reset = useTimeoutFn(() => setHide(true), 5000)[2];
-  useEffect(() => {
-    setHide(false);
-    reset();
-  }, [message, reset]);
-
-  if (hide || !message) {
-    return null;
-  }
-  return <Alert title={message} elevated style={{ position: 'absolute', top: 0, right: 0, width: '50%' }} />;
-};
-
-const parseErrorMessage = (error: Error) => {
-  if (isFetchError(error)) {
-    if (isSystemLinkError(error.data)) {
-      return errorCodes[error.data.error.code] ?? error.data.error.message;
-    }
-
-    return error.data.message || error.statusText;
-  }
-
-  return error.message;
 };

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -16,9 +16,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
   const [errorMsg, setErrorMsg] = useState<string>('');
   const handleError = (error: Error) => setErrorMsg(parseErrorMessage(error));
 
-  const tableMetadata = useAsync(() => {
-    return datasource.getTableMetadata(query.tableId).catch(handleError);
-  }, [query.tableId]);
+  const tableMetadata = useAsync(() => datasource.getTableMetadata(query.tableId).catch(handleError), [query.tableId]);
 
   const runQueryIfValid = () => isValidQuery(query) && onRunQuery();
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,21 +1,26 @@
-import { nbsp } from "utils";
+import { nbsp } from 'utils';
 
 export const decimationMethods = [
   {
     value: 'LOSSY',
     label: 'Lossy',
-    description: nbsp`Completes faster but is less accurate`
+    description: nbsp`Completes faster but is less accurate`,
   },
   {
     value: 'MAX_MIN',
     label: 'Max/min',
-    description: nbsp`Preserves spikes and dips`
+    description: nbsp`Preserves spikes and dips`,
   },
   {
     value: 'ENTRY_EXIT',
     label: 'Entry/exit',
-    description: nbsp`Maintains edges of data (includes max/min)`
+    description: nbsp`Maintains edges of data (includes max/min)`,
   },
 ];
 
 export const defaultDecimationMethod = 'LOSSY';
+
+export const errorCodes: { [key: number]: string } = {
+  [-255134]: 'Invalid table ID',
+  [-255130]: 'Table does not exist',
+};

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -64,7 +64,7 @@ export class DataFrameDataSource extends DataSourceApi<DataframeQuery> {
     }
   }
 
-  async getTableMetadata(id: string) {
+  async getTableMetadata(id?: string) {
     const resolvedId = getTemplateSrv().replace(id);
     if (!resolvedId) {
       return null;
@@ -95,6 +95,16 @@ export class DataFrameDataSource extends DataSourceApi<DataframeQuery> {
           },
         },
       }).pipe(map((res) => res.data))
+    );
+  }
+
+  async queryTables(query: string) {
+    var filter = `name.Contains("${query}")`;
+
+    return lastValueFrom(
+      this.fetch<TableMetadataList>('POST', 'query-tables', { data: { filter, take: 5 } }).pipe(
+        map((res) => res.data.tables)
+      )
     );
   }
 

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -1,0 +1,32 @@
+import { isFetchError } from '@grafana/runtime';
+import { Alert } from '@grafana/ui';
+import { errorCodes } from './constants';
+import React, { useState, useEffect } from 'react';
+import { useTimeoutFn } from 'react-use';
+import { isSystemLinkError } from 'types';
+
+export const FloatingError = ({ message = '' }) => {
+  const [hide, setHide] = useState(false);
+  const reset = useTimeoutFn(() => setHide(true), 5000)[2];
+  useEffect(() => {
+    setHide(false);
+    reset();
+  }, [message, reset]);
+
+  if (hide || !message) {
+    return null;
+  }
+  return <Alert title={message} elevated style={{ position: 'absolute', top: 0, right: 0, width: '50%' }} />;
+};
+
+export const parseErrorMessage = (error: Error) => {
+  if (isFetchError(error)) {
+    if (isSystemLinkError(error.data)) {
+      return errorCodes[error.data.error.code] ?? error.data.error.message;
+    }
+
+    return error.data.message || error.statusText;
+  }
+
+  return error.message;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,3 +58,16 @@ export interface TableDataRows {
   frame: { columns: string[]; data: string[][] };
   continuationToken: string;
 }
+
+export interface SystemLinkError {
+  error: {
+    args: string[];
+    code: number;
+    message: string;
+    name: string;
+  }
+}
+
+export function isSystemLinkError(error: any): error is SystemLinkError {
+  return Boolean(error?.error?.code) && Boolean(error?.error?.name);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,5 @@ import _ from 'lodash';
 // Template literal tag function to replace spaces with non-breaking spaces
 export const nbsp = (strings: TemplateStringsArray, ...values: string[]) =>
   _.flatten(_.zip(strings, values)).join('').replace(/ /g, '\u00a0');
+
+export const isValidId = (id: string) => /^[0-9a-fA-F]{24}$/.test(id);


### PR DESCRIPTION
![Kapture 2022-10-19 at 15 38 02](https://user-images.githubusercontent.com/9257800/196799224-f4b75264-5688-4776-b9f7-92041813f02b.gif)

Adds supports for searching for tables by name using the [AsyncSelect](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-select--basic-select-async) component. This also refactors error handling in the query editor to display a floating notification when things go wrong, matching the rest of Grafana's UI.