### PR TITLE
Allow column picker to wrap instead of overflowing

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -70,7 +70,7 @@ export const QueryEditor = (props: Props) => {
           value={query.tableId ? toOption(query.tableId) : null}
         />
       </InlineField>
-      <InlineField label="Columns" tooltip="Specifies the columns to include in the response data.">
+      <InlineField label="Columns" shrink={true} tooltip="Specifies the columns to include in the response data.">
         <MultiSelect
           isLoading={tableMetadata.loading}
           options={(tableMetadata.value?.columns ?? []).map(c => toOption(c.name))}


### PR DESCRIPTION
<img width="917" alt="Screenshot 2023-03-02 at 5 34 36 PM" src="https://user-images.githubusercontent.com/9257800/222588189-97eeafa9-af24-4097-9435-a07b5864eed5.png"> 

Previously, if you selected a large number of columns, the input field would extend off the screen and be unusable. This change makes it wrap instead.


